### PR TITLE
Feature/7 ユーザ登録の実装

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,12 @@
 from fastapi import FastAPI
-from routers import demo_users
+from routers import users
 
 import os
 
 
 app = FastAPI()
 
-app.include_router(demo_users.router)
+app.include_router(users.router)
 
 # マイグレーションもどきをする(あんまりやりたくない)
 @app.on_event("startup")

--- a/app/migrations/202311171722_create_users_table.py
+++ b/app/migrations/202311171722_create_users_table.py
@@ -1,0 +1,24 @@
+"""
+create_users_table
+"""
+from sqlite3 import Connection, Cursor
+from util.sqlite_util import *
+
+conn: Connection = generate_connect()
+cursor: Cursor = conn.cursor()
+
+# 本当はパスワードをそのまま保存するのはマズい
+sql = create_table_sql(
+    table_name="users",
+    columns="""
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL
+    """)
+
+cursor.execute(sql)
+conn.commit()
+conn.close()
+
+print("created_users_table")

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,0 +1,30 @@
+"""
+ユーザー
+"""
+
+from typing import Optional
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from .util.sqlite_util import *
+
+RESOURCE_NAME: str = "users"
+RESOURCE_COLUMNS: list = ["id", "name", "email", "password"]
+
+router: APIRouter = APIRouter(
+    prefix=f"/{RESOURCE_NAME}",
+    tags=[RESOURCE_NAME],
+)
+
+class UserProp(BaseModel):
+    name: str
+    email: str
+    password: str
+
+@router.post("/register")
+async def create(props: UserProp):
+    # TODO: エラーハンドリング
+    sql: str = "insert into users (name, email, password) values (?, ?, ?);"
+    execute_update(sql, [(props.name, props.email, props.password)])
+
+    return { "status": "ok" }

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -25,6 +25,11 @@ class UserProp(BaseModel):
 async def create(props: UserProp):
     # TODO: エラーハンドリング
     sql: str = "insert into users (name, email, password) values (?, ?, ?);"
-    execute_update(sql, [(props.name, props.email, props.password)])
 
-    return { "status": "ok" }
+    try:
+        execute_update(sql, [(props.name, props.email, props.password)])
+        response = { "status": "ok" }
+    except:
+        response = { "status": "error", "message": "エラーが発生しました" }
+
+    return response


### PR DESCRIPTION
### 解決するissue
<!--#0000を任意のissue番号#nに書き換えると、このプルリクエストがマージされたときに自動的にその番号のissueがクローズされる-->
<!--まだissueをクローズするべきでない場合は子issueを作ってそっちの番号を指定する-->
close #7 

### 概要
<!--プルリクエストの目的を書くところ-->
最小構成のユーザ登録を実装

### 変更内容
<!--何を変更したのか-->
- `users`テーブルを追加
- `users`のrouterを追加

### テスト
- [x] `/users/register`にPOSTリクエストを飛ばして新しくユーザを登録できること
- [x] 同じユーザが複数登録できないこと
![image](https://github.com/618knot/SODH_2023_CIeaST/assets/82982400/b6de8262-6a44-4c74-9cec-19d6529c35bc)


### 備考
<!--他なんかあればどぞ-->
ホントはバリデーションとかもしておかないとだめですが、今回は省略しています。
何か問題が出てきたら対応する形で。