### PR TITLE
fixes #12 SQL実行時の例外処理を実装する

### DIFF
--- a/app/routers/sessions.py
+++ b/app/routers/sessions.py
@@ -31,7 +31,7 @@ async def login(props: LoginProp):
     
     try:
         sql: str = "insert into sessions (user_id) values (?);"
-        execute_update(sql, [user_id,])
+        update_successed = execute_update(sql, [user_id,]) # execute_updateが値を返すように改修したため
 
         sql: str = "select id from sessions where user_id = (?);"
         session_id = execute_query(sql, user_id)[0][0]

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -23,13 +23,8 @@ class UserProp(BaseModel):
 
 @router.post("/register")
 async def create(props: UserProp):
-    # TODO: エラーハンドリング
+    # TODO: 空文字を入力された時の対策
     sql: str = "insert into users (name, email, password) values (?, ?, ?);"
-
-    try:
-        execute_update(sql, [(props.name, props.email, props.password)])
-        response = { "status": "ok" }
-    except:
-        response = { "status": "error", "message": "エラーが発生しました" }
+    response = execute_update(sql, [(props.name, props.email, props.password)])
 
     return response

--- a/app/routers/util/sqlite_util.py
+++ b/app/routers/util/sqlite_util.py
@@ -39,8 +39,8 @@ def execute_update(sql: str, data: list) -> dict:
         response = { "status": "ok" }
     except sqlite3.IntegrityError as e:
         conn.close()  # 例外が出た時のデータベースロックを回避するため
-        response = { "status": "error", "massage": str(e) }
+        response = { "status": "error", "message": str(e) }
     except Exception as e:
         conn.close()  # 例外が出た時のデータベースロックを回避するため
-        response = { "status": "error", "massage": str(e) }
+        response = { "status": "error", "message": str(e) }
     return response


### PR DESCRIPTION
### 解決するissue
<!--#0000を任意のissue番号#nに書き換えると、このプルリクエストがマージされたときに自動的にその番号のissueがクローズされる-->
<!--まだissueをクローズするべきでない場合は子issueを作ってそっちの番号を指定する-->
close #12 

### 概要
<!--プルリクエストの目的を書くところ-->
データベース制約に違反したレコードを登録しようとしたときのデータベース接続が閉じられていなかった問題を修正
### 変更内容
<!--何を変更したのか-->
- execute_updateがレスポンスを返すように変更
- SQL実行時に例外が発生したとき、ユニーク制約への違反を検知してレスポンスを返し、データベースの接続を閉じる
- その他の例外が発生したときもレスポンスを返し、データベースの接続を閉じる
- execute_queryはとりあえずデータベースロックの対策だけした
### テスト
- [ ] 既に存在するレコードと重複したメールアドレスを登録しようとするとエラーとなること
- [ ] 既に存在するレコードと重複しないメールアドレスは登録できること
- [ ] 何度登録をはじかれてもデータベースロックに陥らないこと

### 備考
<!--他なんかあればどぞ-->
